### PR TITLE
[FTR] Remove duplicated commands allow manually and interactive ways

### DIFF
--- a/src/devrules/cli_commands/commit.py
+++ b/src/devrules/cli_commands/commit.py
@@ -1,6 +1,5 @@
 """CLI commands for commit management."""
 
-import os
 from typing import Any, Callable, Dict, Optional
 
 import typer
@@ -270,148 +269,16 @@ def register(app: typer.Typer) -> Dict[str, Callable[..., Any]]:
 
     @app.command()
     @ensure_git_repo()
-    def check_commit(
-        file: str,
-        config: Config = Depends(load_config),
-    ):
-        """Validate commit message format."""
-
-        if not os.path.exists(file):
-            typer.secho(msg.COMMIT_MESSAGE_FILE_NOT_FOUND.format(file), fg=typer.colors.RED)
-            raise typer.Exit(code=1)
-
-        with open(file, "r") as f:
-            message = f.read().strip()
-
-        is_valid, result_message = validate_commit(message, config.commit)
-
-        if is_valid:
-            typer.secho(f"✔ {result_message}", fg=typer.colors.GREEN)
-            raise typer.Exit(code=0)
-        else:
-            typer.secho(f"✘ {result_message}", fg=typer.colors.RED)
-            raise typer.Exit(code=1)
-
-    @app.command()
-    @ensure_git_repo()
+    @emit_events(DevRulesEvent.PRE_COMMIT, DevRulesEvent.POST_COMMIT)
     def commit(
-        message: str,
         skip_checks: bool = typer.Option(
             False, "--skip-checks", help="Skip file validation and documentation checks"
         ),
-        config: Config = Depends(load_config),
-    ):
-        """Validate and commit changes with a properly formatted message."""
-        import subprocess
-
-        typer.secho("Checking commit requirements...", fg=typer.colors.BLUE)
-
-        # Check for forbidden files (unless skipped)
-        if not skip_checks and (config.commit.forbidden_patterns or config.commit.forbidden_paths):
-            is_valid, validation_message = validate_no_forbidden_files(
-                forbidden_patterns=config.commit.forbidden_patterns,
-                forbidden_paths=config.commit.forbidden_paths,
-                check_staged=True,
-            )
-
-            if not is_valid:
-                add_typer_block_message(
-                    header=msg.FORBIDDEN_FILES_DETECTED,
-                    subheader=validation_message,
-                    messages=["💡 Suggestions:"]
-                    + [f"• {suggestion}" for suggestion in get_forbidden_file_suggestions()],
-                    indent_block=False,
-                    use_separator=False,
-                )
-                raise typer.Exit(code=1)
-
-        # Validate commit
-        is_valid, result_message = validate_commit(message, config.commit)
-
-        if not is_valid:
-            typer.secho(f"\n✘ {result_message}", fg=typer.colors.RED)
-            raise typer.Exit(code=1)
-
-        current_branch = get_current_branch()
-
-        # Check if current branch is protected (e.g., staging branches for merging)
-        if config.commit.protected_branch_prefixes:
-            for prefix in config.commit.protected_branch_prefixes:
-                if current_branch.count(prefix):
-                    typer.secho(
-                        msg.CANNOT_COMMIT_TO_PROTECTED_BRANCH.format(current_branch, prefix),
-                        fg=typer.colors.RED,
-                    )
-                    raise typer.Exit(code=1)
-
-        if config.commit.restrict_branch_to_owner:
-            # Check branch ownership to prevent committing on another developer's branch
-            is_owner, ownership_message = validate_branch_ownership(current_branch)
-            if not is_owner:
-                typer.secho(f"✘ {ownership_message}", fg=typer.colors.RED)
-                raise typer.Exit(code=1)
-
-        if config.commit.append_issue_number:
-            # Append issue number if configured and not already present
-            issue_number = get_current_issue_number()
-            if issue_number and f"#{issue_number}" not in message:
-                message = f"#{issue_number} {message}"
-
-        # Get documentation guidance BEFORE commit (while files are still staged)
-        doc_message = None
-        if not skip_checks and config.documentation.show_on_commit and config.documentation.rules:
-            from devrules.validators.documentation import get_relevant_documentation
-
-            has_docs, doc_message = get_relevant_documentation(
-                rules=config.documentation.rules,
-                base_branch="HEAD",
-                show_files=True,
-            )
-            if not has_docs:
-                doc_message = None
-
-        if config.commit.auto_stage:
-            typer.secho("Auto staging files...", fg=typer.colors.GREEN)
-            subprocess.run(
-                [
-                    "git",
-                    "add",
-                    "--all",
-                ],
-                check=True,
-            )
-
-        options = []
-        if config.commit.gpg_sign:
-            options.append("-S")
-        if config.commit.allow_hook_bypass:
-            options.append("-n")
-        options.append("-m")
-        options.append(message)
-        try:
-            subprocess.run(
-                [
-                    "git",
-                    "commit",
-                    *options,
-                ],
-                check=True,
-            )
-            typer.secho(f"\n{msg.COMMITTED_CHANGES}", fg=typer.colors.GREEN)
-
-            # Show context-aware documentation AFTER commit
-            if doc_message:
-                typer.secho(f"{doc_message}", fg=typer.colors.YELLOW)
-        except subprocess.CalledProcessError as e:
-            typer.secho(f"\n{msg.FAILED_TO_COMMIT_CHANGES.format(e)}", fg=typer.colors.RED)
-            raise typer.Exit(code=1) from e
-
-    @app.command()
-    @ensure_git_repo()
-    @emit_events(DevRulesEvent.PRE_COMMIT, DevRulesEvent.POST_COMMIT)
-    def icommit(
-        skip_checks: bool = typer.Option(
-            False, "--skip-checks", help="Skip file validation and documentation checks"
+        message: str = typer.Option(
+            None,
+            "--message",
+            "-m",
+            help="Commit message",
         ),
         config: Config = Depends(load_config),
     ):
@@ -423,7 +290,8 @@ def register(app: typer.Typer) -> Dict[str, Callable[..., Any]]:
         _validate_branch_protection(current_branch, config)
         _validate_ownership(current_branch, config)
         # Build commit message
-        message = build_commit_message_interactive(config=config, tags=config.commit.tags)
+        if not message:
+            message = build_commit_message_interactive(config=config, tags=config.commit.tags)
         # Validate commit message
         _validate_commit(message, config)
         # Perform post-commit validation operations
@@ -435,7 +303,5 @@ def register(app: typer.Typer) -> Dict[str, Callable[..., Any]]:
         _perform_commit(message=message, config=config, doc_message=doc_message)
 
     return {
-        "check_commit": check_commit,
         "commit": commit,
-        "icommit": icommit,
     }

--- a/src/devrules/cli_commands/pr.py
+++ b/src/devrules/cli_commands/pr.py
@@ -1,18 +1,20 @@
 """CLI commands for pull requests."""
 
 import re
+import subprocess
 from typing import Any, Callable, Dict, Optional
 
 import typer
 from typer_di import Depends
 from yaspin import yaspin
 
+from devrules.cli_commands.prompters import Prompter
+from devrules.cli_commands.prompters.factory import get_default_prompter
 from devrules.config import Config, load_config
 from devrules.core.enum import DevRulesEvent
 from devrules.core.git_service import get_current_branch, remote_branch_exists
 from devrules.core.github_service import ensure_gh_installed, fetch_pr_info
 from devrules.messages import pr as msg
-from devrules.utils import gum
 from devrules.utils.decorators import emit_events, ensure_git_repo
 from devrules.utils.typer import add_typer_block_message
 from devrules.validators.documentation import display_documentation_guidance
@@ -23,521 +25,300 @@ from devrules.validators.pr_target import (
     validate_pr_target,
 )
 
+prompter: Prompter = get_default_prompter()
 
-def select_base_branch_interactive(allowed_targets: list[str], suggested: str = "develop") -> str:
-    """Select base branch interactively using gum or typer fallback.
 
-    Args:
-        allowed_targets: List of allowed target branches
-        suggested: Suggested default branch
+def derive_pr_title(branch: str) -> str:
+    """Derive a human-friendly PR title from a branch name."""
+    prefix = None
+    name_part = branch
 
-    Returns:
-        Selected base branch
-    """
+    if "/" in branch:
+        prefix, name_part = branch.split("/", 1)
+
+    prefix_to_tag = {
+        "feature": "FTR",
+        "bugfix": "FIX",
+        "hotfix": "FIX",
+        "docs": "DOCS",
+        "release": "REF",
+    }
+
+    tag = prefix_to_tag.get(prefix or "", "FTR")
+
+    issue_match = re.match(r"^(\d+)-(.*)$", name_part)
+    if issue_match:
+        name_part = issue_match.group(2)
+
+    words = [w for w in name_part.replace("_", "-").split("-") if w]
+    humanized = " ".join(words).lower()
+
+    if humanized:
+        humanized = humanized.capitalize()
+
+    return f"[{tag}] {humanized}" if humanized else f"[{tag}] {branch}"
+
+
+def select_base_branch_interactive(
+    allowed_targets: list[str],
+    suggested: str,
+) -> str:
+    """Select base branch using the unified prompter."""
+    prompter.header("🎯 Select Target Branch")
+
     if not allowed_targets:
         allowed_targets = ["develop", "main", "master"]
 
-    if gum.is_available():
-        print(gum.style("🎯 Select Target Branch", foreground=81, bold=True))
-        selected = gum.choose(allowed_targets, header="Select base branch for PR:")
-        if selected:
-            return selected if isinstance(selected, str) else selected[0]
-        return suggested
-    else:
-        typer.echo("\n🎯 Select base branch:")
-        for idx, branch in enumerate(allowed_targets, 1):
-            marker = " (suggested)" if branch == suggested else ""
-            typer.echo(f"  {idx}. {branch}{marker}")
+    if suggested in allowed_targets:
+        allowed_targets = [suggested] + [b for b in allowed_targets if b != suggested]
 
-        choice = typer.prompt("Enter number", type=int, default=1)
-        if 1 <= choice <= len(allowed_targets):
-            return allowed_targets[choice - 1]
+    selected = prompter.choose(
+        allowed_targets,
+        header="Select base branch for PR:",
+    )
+
+    if not selected:
+        prompter.warning("No branch selected, using suggested.")
         return suggested
+
+    return selected
+
+
+def run_pr_validations(
+    *,
+    current_branch: str,
+    base: str,
+    skip_checks: bool,
+    config: Config,
+):
+    """Run all PR validations."""
+    if skip_checks:
+        return
+
+    is_valid_base, base_message = validate_pr_base_not_protected(
+        current_branch,
+        config.commit.protected_branch_prefixes,
+    )
+    if not is_valid_base:
+        prompter.error(base_message)
+        raise prompter.exit(code=1)
+
+    is_valid_target, target_message = validate_pr_target(
+        source_branch=current_branch,
+        target_branch=base,
+        config=config.pr,
+    )
+
+    if not is_valid_target:
+        suggested = suggest_pr_target(current_branch, config.pr)
+        messages = [target_message]
+
+        if suggested:
+            messages.append(f"💡 Suggested target: {suggested}")
+
+        add_typer_block_message(
+            header=msg.INVALID_PR_TARGET,
+            subheader="",
+            messages=messages,
+            indent_block=False,
+        )
+        raise prompter.exit(code=1)
+
+
+def create_pr_internal(
+    *,
+    base: str,
+    title: str,
+    project: Optional[str],
+    skip_checks: bool,
+    auto_push: bool,
+    config: Config,
+):
+    """Shared PR creation engine."""
+    ensure_gh_installed()
+
+    current_branch = get_current_branch()
+
+    if current_branch == base:
+        prompter.error(msg.CURRENT_BRANCH_SAME_AS_BASE)
+        raise prompter.exit(code=1)
+
+    run_pr_validations(
+        current_branch=current_branch,
+        base=base,
+        skip_checks=skip_checks,
+        config=config,
+    )
+
+    if not skip_checks and config.documentation.show_on_pr and config.documentation.rules:
+        display_documentation_guidance(
+            rules=config.documentation.rules,
+            base_branch=base,
+            show_files=True,
+        )
+
+    # Issue status validation
+    if config.pr.require_issue_status_check:
+        from devrules.validators.pr import validate_pr_issue_status
+
+        with yaspin(text="🔍 Checking issue status...") as spinner:
+            project_override = [project] if project else None
+            is_valid, messages = validate_pr_issue_status(
+                current_branch,
+                config.pr,
+                config.github,
+                project_override=project_override,
+            )
+            spinner.stop()
+
+            for m in messages:
+                if "✔" in m or "ℹ" in m:
+                    prompter.success(m)
+                elif "⚠" in m:
+                    prompter.warning(m)
+                else:
+                    prompter.error(m)
+
+            if not is_valid:
+                prompter.error("Cannot create PR: Issue status check failed")
+                raise prompter.exit(code=1)
+
+    # Confirmation
+    prompter.info(f"🔀 {current_branch} → {base}")
+    prompter.info(f"📝 Title: {title}")
+
+    if not prompter.confirm("Create this PR?", default=True):
+        prompter.warning(msg.PR_CANCELLED)
+        raise prompter.exit(code=0)
+
+    # Auto-push
+    if auto_push:
+        if not remote_branch_exists(current_branch):
+            with yaspin(text=f"🚀 Pushing '{current_branch}'..."):
+                subprocess.run(
+                    ["git", "push", "-u", "origin", current_branch],
+                    check=True,
+                )
+        else:
+            prompter.info(f"Branch '{current_branch}' already exists on remote, skipping push.")
+
+    # Create PR
+    cmd = [
+        "gh",
+        "pr",
+        "create",
+        "--base",
+        base,
+        "--head",
+        current_branch,
+        "--title",
+        title,
+        "--fill",
+    ]
+
+    try:
+        subprocess.run(cmd, check=True)
+    except subprocess.CalledProcessError as e:
+        prompter.error(msg.FAILED_TO_CREATE_PR.format(e))
+        raise prompter.exit(code=1)
+
+    prompter.success(f"Created pull request: {title}")
 
 
 def register(app: typer.Typer) -> Dict[str, Callable[..., Any]]:
-    """Register PR commands.
-
-    Args:
-        app: Typer application instance.
-
-    Returns:
-        Dictionary mapping command names to their functions.
-    """
+    """Register PR commands."""
 
     @app.command()
+    @emit_events(DevRulesEvent.PRE_PR)
     @ensure_git_repo()
     def create_pr(
-        base: str = typer.Option(
-            "develop", "--base", "-b", help="Base branch for the pull request"
-        ),
-        project: Optional[str] = typer.Option(
-            None,
-            "--project",
-            "-p",
-            help="Project to check issue status against (faster than checking all)",
-        ),
-        skip_checks: bool = typer.Option(
-            False, "--skip-checks", help="Skip target validation and documentation checks"
-        ),
-        auto_push: Optional[bool] = typer.Option(
-            None, "--auto-push/--no-auto-push", help="Push branch before creating PR"
-        ),
+        base: str = typer.Option("develop", "--base", "-b"),
+        project: Optional[str] = typer.Option(None, "--project", "-p"),
+        skip_checks: bool = typer.Option(False, "--skip-checks"),
+        auto_push: Optional[bool] = typer.Option(None, "--auto-push/--no-auto-push"),
         config: Config = Depends(load_config),
     ):
-        """Create a GitHub pull request for the current branch against the base branch."""
-        import subprocess
+        """Interactive PR creation."""
+        prompter.header("🔀 Create Pull Request")
 
-        # Determine current branch
         current_branch = get_current_branch()
+        prompter.info(f"📌 Current branch: {current_branch}")
 
-        # Validate that current branch is not protected (staging branches)
-        if not skip_checks:
-            is_valid_base, base_message = validate_pr_base_not_protected(
-                current_branch,
-                config.commit.protected_branch_prefixes,
-            )
-            if not is_valid_base:
-                typer.secho(f"\n✘ {base_message}", fg=typer.colors.RED)
-                raise typer.Exit(code=1)
+        allowed_targets = config.pr.allowed_targets or ["develop", "main", "master"]
+        suggested = suggest_pr_target(current_branch, config.pr) or "develop"
 
-        # Validate PR target branch
-        if not skip_checks:
-            is_valid_target, target_message = validate_pr_target(
-                source_branch=current_branch,
-                target_branch=base,
-                config=config.pr,
-            )
+        base = select_base_branch_interactive(allowed_targets, suggested)
 
-            if not is_valid_target:
-                suggested = suggest_pr_target(current_branch, config.pr)
-                msg_list = [target_message]
-                if suggested:
-                    msg_list.append(f"💡 Suggested target: {suggested}")
-                    msg_list.append(f"   Try: devrules create-pr --base {suggested}")
+        title = derive_pr_title(current_branch)
 
-                add_typer_block_message(
-                    header=msg.INVALID_PR_TARGET,
-                    subheader="",
-                    messages=msg_list,
-                    indent_block=False,
-                )
-                raise typer.Exit(code=1)
+        edited = prompter.input_text(
+            header="📝 PR Title:",
+            default=title,
+            placeholder=title,
+        )
+        if edited:
+            title = edited
 
-        # Show context-aware documentation
-        if not skip_checks and config.documentation.show_on_pr and config.documentation.rules:
-            display_documentation_guidance(
-                rules=config.documentation.rules,
-                base_branch=base,
-                show_files=True,
-            )
-
-        if current_branch == base:
-            typer.secho(msg.CURRENT_BRANCH_SAME_AS_BASE, fg=typer.colors.RED)
-            raise typer.Exit(code=1)
-
-        # Derive PR title from branch name
-        # Example: feature/add-create-pr-command -> [FTR] Add create pr command
-        prefix = None
-        name_part = current_branch
-        if "/" in current_branch:
-            prefix, name_part = current_branch.split("/", 1)
-
-        # Map common prefixes to tags, falling back to FTR
-        prefix_to_tag = {
-            "feature": "FTR",
-            "bugfix": "FIX",
-            "hotfix": "FIX",
-            "docs": "DOCS",
-            "release": "REF",
-        }
-
-        tag = prefix_to_tag.get(prefix or "", "FTR")
-
-        # Strip a leading numeric issue and hyphen if present (e.g. 123-add-thing)
-        name_core = name_part
-        issue_match = re.match(r"^(\d+)-(.*)$", name_core)
-        if issue_match:
-            name_core = issue_match.group(2)
-
-        words = name_core.replace("_", "-").split("-")
-        words = [w for w in words if w]
-        humanized = " ".join(words).lower()
-        if humanized:
-            humanized = humanized[0].upper() + humanized[1:]
-
-        pr_title = f"[{tag}] {humanized}" if humanized else f"[{tag}] {current_branch}"
-
-        # Validate issue status if enabled
-        if config.pr.require_issue_status_check:
-            from devrules.validators.pr import validate_pr_issue_status
-
-            with yaspin(text="🔍 Checking issue status...") as spinner:
-                # Use CLI project option if provided, otherwise use config
-                project_override = [project] if project else None
-                is_valid, messages = validate_pr_issue_status(
-                    current_branch, config.pr, config.github, project_override=project_override
-                )
-                spinner.stop()
-
-                for message in messages:
-                    if "✔" in message or "ℹ" in message:
-                        typer.secho(message, fg=typer.colors.GREEN)
-                    elif "⚠" in message:
-                        typer.secho(message, fg=typer.colors.YELLOW)
-                    else:
-                        typer.secho(message, fg=typer.colors.RED)
-
-                if not is_valid:
-                    typer.echo()
-                    typer.secho(
-                        "✘ Cannot create PR: Issue status check failed",
-                        fg=typer.colors.RED,
-                    )
-                    raise typer.Exit(code=1)
-
-                typer.echo()
-
-        # Confirm before creating
-        if gum.is_available():
-            print("\n📋 Summary:")
-            print(
-                f"   Branch: {gum.style(current_branch, foreground=212)} → {gum.style(base, foreground=82)}"
-            )
-            print(f"   Title:  {gum.style(pr_title, foreground=222)}")
-            confirmed = gum.confirm("Create this PR?")
-            if confirmed is False:
-                typer.secho(msg.PR_CANCELLED, fg=typer.colors.YELLOW)
-                raise typer.Exit(code=0)
-        else:
-            typer.echo(f"\n📝 Title: {pr_title}")
-            if not typer.confirm("\nCreate this PR?", default=True):
-                typer.secho(msg.PR_CANCELLED, fg=typer.colors.YELLOW)
-                raise typer.Exit(code=0)
-
-        # Auto-push if enabled
-        # check branch is not already in remote
-        if config.pr.auto_push or auto_push:
-            with yaspin(text=f"Checking if branch '{current_branch}' exists on remote..."):
-                exists_remotely = remote_branch_exists(current_branch)
-            if not exists_remotely:
-                with yaspin(
-                    text=f"🚀 Pushing branch '{current_branch}' to origin...",
-                    color=typer.colors.CYAN,
-                ):
-                    try:
-                        subprocess.run(
-                            ["git", "push", "-u", "origin", current_branch],
-                            check=True,
-                            capture_output=False,  # Let user see push progress
-                        )
-                    except subprocess.CalledProcessError as e:
-                        typer.secho(f"✘ Failed to push branch: {e}", fg=typer.colors.RED)
-                        if not typer.confirm("Continue creating PR anyway?", default=False):
-                            raise typer.Exit(code=1)
-            else:
-                typer.secho(
-                    f"\nℹ Branch '{current_branch}' already exists on remote, skipping push.",
-                    fg=typer.colors.BLUE,
-                )
-
-        cmd = [
-            "gh",
-            "pr",
-            "create",
-            "--base",
-            base,
-            "--head",
-            current_branch,
-            "--title",
-            pr_title,
-            "--fill",
-        ]
-
-        try:
-            subprocess.run(cmd, check=True)
-        except subprocess.CalledProcessError as e:
-            typer.secho(msg.FAILED_TO_CREATE_PR.format(e), fg=typer.colors.RED)
-            raise typer.Exit(code=1)
-
-        typer.secho(f"✔ Created pull request: {pr_title}", fg=typer.colors.GREEN)
+        create_pr_internal(
+            base=base,
+            title=title,
+            project=project,
+            skip_checks=skip_checks,
+            auto_push=auto_push or config.pr.auto_push,
+            config=config,
+        )
 
     @app.command()
     def check_pr(
         pr_number: int,
-        owner: Optional[str] = typer.Option(None, "--owner", "-o", help="GitHub repository owner"),
-        repo: Optional[str] = typer.Option(None, "--repo", "-r", help="GitHub repository name"),
+        owner: Optional[str] = typer.Option(None, "--owner", "-o"),
+        repo: Optional[str] = typer.Option(None, "--repo", "-r"),
         config: Config = Depends(load_config),
     ):
         """Validate PR size and title format."""
-        # Use CLI arguments if provided, otherwise fall back to config
+        prompter.header("🔍 Validate Pull Request")
         github_owner = owner or config.github.owner
         github_repo = repo or config.github.repo
 
         if not github_owner or not github_repo:
-            typer.secho(
-                "✘ GitHub owner and repo must be provided via CLI arguments (--owner, --repo) "
-                "or configured in the config file under [github] section.",
-                fg=typer.colors.RED,
-            )
-            raise typer.Exit(code=1)
+            prompter.error("GitHub owner and repo must be provided via CLI or config.")
+            raise prompter.exit(code=1)
 
         try:
-            pr_info = fetch_pr_info(github_owner, github_repo, pr_number, config.github)
-        except ValueError as e:
-            typer.secho(f"✘ {str(e)}", fg=typer.colors.RED)
-            raise typer.Exit(code=1)
+            pr_info = fetch_pr_info(
+                github_owner,
+                github_repo,
+                pr_number,
+                config.github,
+            )
         except Exception as e:
-            typer.secho(f"✘ Error fetching PR: {str(e)}", fg=typer.colors.RED)
-            raise typer.Exit(code=1)
+            prompter.error(str(e))
+            raise prompter.exit(code=1)
 
-        typer.echo(f"PR Title: {pr_info.title}")
-        typer.echo(f"Total LOC: {pr_info.additions + pr_info.deletions}")
-        typer.echo(f"Files changed: {pr_info.changed_files}")
-        typer.echo("")
+        prompter.info(f"PR Title: {pr_info.title}")
+        prompter.info(f"Total LOC: {pr_info.additions + pr_info.deletions}")
+        prompter.info(f"Files changed: {pr_info.changed_files}")
 
-        # Get current branch for status validation
         current_branch = None
         if config.pr.require_issue_status_check:
             try:
                 current_branch = get_current_branch()
             except Exception:
-                # If we can't get current branch, validation will skip status check
                 pass
 
         is_valid, messages = validate_pr(
-            pr_info, config.pr, current_branch=current_branch, github_config=config.github
+            pr_info,
+            config.pr,
+            current_branch=current_branch,
+            github_config=config.github,
         )
 
-        for message in messages:
-            if "✔" in message or "ℹ" in message:
-                typer.secho(message, fg=typer.colors.GREEN)
-            elif "⚠" in message:
-                typer.secho(message, fg=typer.colors.YELLOW)
-            else:
-                typer.secho(message, fg=typer.colors.RED)
+        for m in messages:
+            prompter.success(m) if is_valid else prompter.error(m)
 
-        raise typer.Exit(code=0 if is_valid else 1)
-
-    @app.command()
-    @emit_events(DevRulesEvent.PRE_PR)
-    @ensure_git_repo()
-    def ipr(
-        project: Optional[str] = typer.Option(
-            None,
-            "--project",
-            "-p",
-            help="Project to check issue status against",
-        ),
-        skip_checks: bool = typer.Option(
-            False, "--skip-checks", help="Skip target validation and documentation checks"
-        ),
-        config: Config = Depends(load_config),
-    ):
-        """Interactive PR creation - select target branch with guided prompts."""
-        import subprocess
-
-        ensure_gh_installed()
-
-        current_branch = get_current_branch()
-
-        # Header
-        if gum.is_available():
-            print(gum.style("🔀 Create Pull Request", foreground=81, bold=True))
-            print(gum.style("=" * 50, foreground=81))
-            typer.echo(f"\n📌 Current branch: {current_branch}")
-        else:
-            add_typer_block_message(
-                header="🔀 Create Pull Request",
-                subheader=f"📌 Current branch: {current_branch}",
-                messages=[],
-                indent_block=False,
-            )
-
-        # Validate that current branch is not protected
-        if not skip_checks:
-            is_valid_base, base_message = validate_pr_base_not_protected(
-                current_branch,
-                config.commit.protected_branch_prefixes,
-            )
-            if not is_valid_base:
-                typer.secho(f"\n✘ {base_message}", fg=typer.colors.RED)
-                raise typer.Exit(code=1)
-
-        # Get allowed targets from config
-        allowed_targets = config.pr.allowed_targets or ["develop", "main", "master"]
-        suggested = suggest_pr_target(current_branch, config.pr) or "develop"
-
-        # Interactive target selection
-        base = select_base_branch_interactive(allowed_targets, suggested)
-
-        # Validate PR target branch
-        if not skip_checks:
-            is_valid_target, target_message = validate_pr_target(
-                source_branch=current_branch,
-                target_branch=base,
-                config=config.pr,
-            )
-
-            if not is_valid_target:
-                add_typer_block_message(
-                    header=msg.INVALID_PR_TARGET,
-                    subheader="",
-                    messages=[target_message],
-                    indent_block=False,
-                )
-                raise typer.Exit(code=1)
-
-        # Show context-aware documentation
-        if not skip_checks and config.documentation.show_on_pr and config.documentation.rules:
-            display_documentation_guidance(
-                rules=config.documentation.rules,
-                base_branch=base,
-                show_files=True,
-            )
-
-        if current_branch == base:
-            typer.secho(
-                "✘ Current branch is the same as the base branch; nothing to create a PR for.",
-                fg=typer.colors.RED,
-            )
-            raise typer.Exit(code=1)
-
-        # Derive PR title from branch name
-        prefix = None
-        name_part = current_branch
-        if "/" in current_branch:
-            prefix, name_part = current_branch.split("/", 1)
-
-        prefix_to_tag = {
-            "feature": "FTR",
-            "bugfix": "FIX",
-            "hotfix": "FIX",
-            "docs": "DOCS",
-            "release": "REF",
-        }
-
-        tag = prefix_to_tag.get(prefix or "", "FTR")
-
-        name_core = name_part
-        issue_match = re.match(r"^(\d+)-(.*)$", name_core)
-        if issue_match:
-            name_core = issue_match.group(2)
-
-        words = name_core.replace("_", "-").split("-")
-        words = [w for w in words if w]
-        humanized = " ".join(words).lower()
-        if humanized:
-            humanized = humanized[0].upper() + humanized[1:]
-
-        pr_title = f"[{tag}] {humanized}" if humanized else f"[{tag}] {current_branch}"
-
-        # Allow editing the PR title
-        if gum.is_available():
-            edited_title = gum.input_text_with_history(
-                prompt_type="pr_title",
-                placeholder=pr_title,
-                header="📝 PR Title (edit or press Enter to accept):",
-                default=pr_title,
-            )
-            if edited_title:
-                pr_title = edited_title
-        else:
-            typer.echo(f"\n📝 Suggested PR title: {pr_title}")
-            if typer.confirm("Edit title?", default=False):
-                pr_title = typer.prompt("Enter new title", default=pr_title)
-
-        # Validate issue status if enabled
-        if config.pr.require_issue_status_check:
-            from devrules.validators.pr import validate_pr_issue_status
-
-            with yaspin(text="🔍 Checking issue status...") as spinner:
-                project_override = [project] if project else None
-                is_valid, messages = validate_pr_issue_status(
-                    current_branch, config.pr, config.github, project_override=project_override
-                )
-                spinner.stop()
-                for message in messages:
-                    if "✔" in message or "ℹ" in message:
-                        typer.secho(message, fg=typer.colors.GREEN)
-                    elif "⚠" in message:
-                        typer.secho(message, fg=typer.colors.YELLOW)
-                    else:
-                        typer.secho(message, fg=typer.colors.RED)
-
-                if not is_valid:
-                    typer.echo()
-                    typer.secho(
-                        "✘ Cannot create PR: Issue status check failed",
-                        fg=typer.colors.RED,
-                    )
-                    raise typer.Exit(code=1)
-
-            typer.echo()
-
-        # Confirm before creating
-        if gum.is_available():
-            print("\n📋 Summary:")
-            print(
-                f"   Branch: {gum.style(current_branch, foreground=212)} → {gum.style(base, foreground=82)}"
-            )
-            print(f"   Title:  {gum.style(pr_title, foreground=222)}")
-            confirmed = gum.confirm("Create this PR?")
-            if confirmed is False:
-                typer.secho(msg.PR_CANCELLED, fg=typer.colors.YELLOW)
-                raise typer.Exit(code=0)
-        else:
-            typer.echo(f"\n📝 Title: {pr_title}")
-            if not typer.confirm("\nCreate this PR?", default=True):
-                typer.secho(msg.PR_CANCELLED, fg=typer.colors.YELLOW)
-                raise typer.Exit(code=0)
-
-        # Auto-push if enabled
-        # check branch is not already in remote
-        if config.pr.auto_push:
-            if not remote_branch_exists(current_branch):
-                typer.secho(
-                    f"\n🚀 Pushing branch '{current_branch}' to origin...", fg=typer.colors.CYAN
-                )
-                try:
-                    subprocess.run(
-                        ["git", "push", "-u", "origin", current_branch],
-                        check=True,
-                        capture_output=False,  # Let user see push progress
-                    )
-                except subprocess.CalledProcessError as e:
-                    typer.secho(f"✘ Failed to push branch: {e}", fg=typer.colors.RED)
-                    if not typer.confirm("Continue creating PR anyway?", default=False):
-                        raise typer.Exit(code=1)
-            else:
-                typer.secho(
-                    f"\nℹ Branch '{current_branch}' already exists on remote, skipping push.",
-                    fg=typer.colors.BLUE,
-                )
-
-        cmd = [
-            "gh",
-            "pr",
-            "create",
-            "--base",
-            base,
-            "--head",
-            current_branch,
-            "--title",
-            pr_title,
-            "--fill",
-        ]
-
-        try:
-            subprocess.run(cmd, check=True)
-        except subprocess.CalledProcessError as e:
-            typer.secho(msg.FAILED_TO_CREATE_PR.format(e), fg=typer.colors.RED)
-            raise typer.Exit(code=1)
-
-        typer.secho(f"\n✔ Created pull request: {pr_title}", fg=typer.colors.GREEN)
+        raise prompter.exit(code=0 if is_valid else 1)
 
     return {
         "create_pr": create_pr,
         "check_pr": check_pr,
-        "ipr": ipr,
     }

--- a/src/devrules/utils/aliases.py
+++ b/src/devrules/utils/aliases.py
@@ -3,13 +3,10 @@
 import typer
 
 ALIAS_MAP = {
-    "check_branch": ["cb"],
-    "check_commit": ["cc"],
     "check_pr": ["cpr"],
     "init_config": ["init"],
     "create_branch": ["nb"],
     "commit": ["ci"],
-    "icommit": ["ic"],
     "create_pr": ["pr"],
     "ipr": ["ipr"],
     "list_owned_branches": ["lob"],

--- a/src/devrules/utils/decorators.py
+++ b/src/devrules/utils/decorators.py
@@ -53,7 +53,7 @@ def emit_events(*events: list[DevRulesEvent]) -> Callable[[Callable[P, T]], Call
             custom_rules: list[RuleDefinition] = []
             for event in events:
                 custom_rules.extend(attach_event(event))
-            prompter.header("Running custom rules...")
+            prompter.header("Running custom rules...") if custom_rules else None
             for custom_rule in custom_rules:
                 prompter.info(f"Running custom rule: {custom_rule.name}")
                 prompted_kwargs = prompt_for_rule_arguments(custom_rule.name)

--- a/src/devrules/validators/pr.py
+++ b/src/devrules/validators/pr.py
@@ -33,7 +33,7 @@ def validate_pr_issue_status(
     issue_number = _extract_issue_number(current_branch)
     if issue_number is None:
         # No issue number in branch, skip check
-        messages.append("ℹ No issue number found in branch name - status check skipped")
+        messages.append("No issue number found in branch name - status check skipped")
         return True, messages
 
     # Determine which projects to check
@@ -122,9 +122,7 @@ def validate_pr(
             if not status_valid:
                 is_valid = False
         else:
-            messages.append(
-                "⚠ Issue status check enabled but branch/config not provided - skipping"
-            )
+            messages.append("Issue status check enabled but branch/config not provided - skipping")
 
     total_loc = pr_info.additions + pr_info.deletions
 
@@ -132,23 +130,23 @@ def validate_pr(
     if config.require_title_tag:
         pattern = re.compile(config.title_pattern)
         if pattern.match(pr_info.title):
-            messages.append("✔ PR title valid")
+            messages.append("PR title valid")
         else:
-            messages.append("✘ PR title does not follow required format")
+            messages.append("PR title does not follow required format")
             is_valid = False
 
     # Check LOC
     if total_loc > config.max_loc:
-        messages.append(f"✘ PR too large: {total_loc} LOC (max: {config.max_loc})")
+        messages.append(f"PR too large: {total_loc} LOC (max: {config.max_loc})")
         is_valid = False
     else:
-        messages.append(f"✔ PR size acceptable: {total_loc} LOC")
+        messages.append(f"PR size acceptable: {total_loc} LOC")
 
     # Check files
     if pr_info.changed_files > config.max_files:
-        messages.append(f"✘ Too many files: {pr_info.changed_files} (max: {config.max_files})")
+        messages.append(f"Too many files: {pr_info.changed_files} (max: {config.max_files})")
         is_valid = False
     else:
-        messages.append(f"✔ File count acceptable: {pr_info.changed_files}")
+        messages.append(f"File count acceptable: {pr_info.changed_files}")
 
     return is_valid, messages


### PR DESCRIPTION
## **User description**
- **[REF] Remove unnecessary commit functions**
- **[REF] Refactor: add run_validations, fetch_doc_guidance, drop aliases**


___

## **CodeAnt-AI Description**
**Unify commit commands into a single command supporting -m and interactive flow**

### What Changed
- The CLI now exposes one commit command that accepts a message via --message/-m or launches the interactive guided prompts when no message is provided.
- Validation steps (forbidden files, protected-branch checks, branch ownership) run consistently before committing via a single validations flow.
- Issue numbers are correctly appended to the commit message and returned for subsequent steps; context-aware documentation guidance is fetched and shown around the commit when enabled.
- Removed the separate check_commit command and removed short aliases for the removed commit-related commands.

### Impact
`✅ Single command for interactive and scripted commits`
`✅ Fewer accidental commits to protected or other developers' branches`
`✅ Clearer commit messages with issue numbers and documentation guidance`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
