### PR TITLE
[FTR] Configure prefixes to tag mapping for pr titles

### DIFF
--- a/src/devrules/cli_commands/pr.py
+++ b/src/devrules/cli_commands/pr.py
@@ -58,8 +58,6 @@ def select_base_branch_interactive(
     suggested: str,
 ) -> str:
     """Select base branch using the unified prompter."""
-    prompter.header("🎯 Select Target Branch")
-
     if not allowed_targets:
         allowed_targets = ["develop", "main", "master"]
 
@@ -68,7 +66,7 @@ def select_base_branch_interactive(
 
     selected = prompter.choose(
         allowed_targets,
-        header="Select base branch for PR:",
+        header="🎯 Select Target Branch",
     )
 
     if not selected:

--- a/src/devrules/cli_commands/pr.py
+++ b/src/devrules/cli_commands/pr.py
@@ -28,7 +28,7 @@ from devrules.validators.pr_target import (
 prompter: Prompter = get_default_prompter()
 
 
-def derive_pr_title(branch: str) -> str:
+def derive_pr_title(branch: str, config: Config) -> str:
     """Derive a human-friendly PR title from a branch name."""
     prefix = None
     name_part = branch
@@ -36,15 +36,9 @@ def derive_pr_title(branch: str) -> str:
     if "/" in branch:
         prefix, name_part = branch.split("/", 1)
 
-    prefix_to_tag = {
-        "feature": "FTR",
-        "bugfix": "FIX",
-        "hotfix": "FIX",
-        "docs": "DOCS",
-        "release": "REF",
-    }
-
-    tag = prefix_to_tag.get(prefix or "", "FTR")
+    tag = None
+    if prefix_to_tag := config.pr.prefixes_tags:
+        tag = prefix_to_tag.get(prefix or "", "FTR")
 
     issue_match = re.match(r"^(\d+)-(.*)$", name_part)
     if issue_match:
@@ -56,7 +50,7 @@ def derive_pr_title(branch: str) -> str:
     if humanized:
         humanized = humanized.capitalize()
 
-    return f"[{tag}] {humanized}" if humanized else f"[{tag}] {branch}"
+    return f"[{tag}] {humanized}" if tag else humanized
 
 
 def select_base_branch_interactive(
@@ -249,7 +243,7 @@ def register(app: typer.Typer) -> Dict[str, Callable[..., Any]]:
 
         base = select_base_branch_interactive(allowed_targets, suggested)
 
-        title = derive_pr_title(current_branch)
+        title = derive_pr_title(current_branch, config)
 
         edited = prompter.input_text(
             header="📝 PR Title:",

--- a/src/devrules/config.py
+++ b/src/devrules/config.py
@@ -58,6 +58,7 @@ class PRConfig:
     allowed_targets: list = field(default_factory=list)
     target_rules: list = field(default_factory=list)
     auto_push: bool = False
+    prefixes_tags: dict = field(default_factory=dict)
 
 
 @dataclass


### PR DESCRIPTION
## **User description**
- **[REF] Add configurable PR title prefixes via config**
- **[REF] Add emoji header to base branch prompt in PR CLI.**


___

## **CodeAnt-AI Description**
Configure PR title prefixes from project config and improve interactive prompts

### What Changed
- PR title prefix mapping is now read from the project's configuration, allowing teams to define which tag (e.g., FTR, FIX, DOCS) is applied based on branch prefixes
- If no prefix-to-tag mapping is provided, derived titles no longer force a default bracketed tag and will return a human-friendly title without a tag
- The interactive "Select base branch" prompt now shows a clear emoji header ("🎯 Select Target Branch")
- PR creation uses the configured mappings when pre-filling the PR title

### Impact
`✅ Customizable PR title tags`
`✅ PR titles omit default tag when mapping is absent`
`✅ Clearer target branch selection prompt`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
